### PR TITLE
カレンダーレイアウトの更新

### DIFF
--- a/dist/esm/Calendar.js
+++ b/dist/esm/Calendar.js
@@ -484,7 +484,7 @@ var Calendar = /*#__PURE__*/function (_Component) {
     }
   }, {
     key: "renderNavigation",
-    value: function renderNavigation(secound) {
+    value: function renderNavigation(secound, mode) {
       var showNavigation = this.props.showNavigation;
 
       if (!showNavigation) {
@@ -520,6 +520,7 @@ var Calendar = /*#__PURE__*/function (_Component) {
         locale: locale,
         maxDate: maxDate,
         minDate: minDate,
+        mode: mode,
         navigationAriaLabel: navigationAriaLabel,
         navigationLabel: navigationLabel,
         next2AriaLabel: next2AriaLabel,
@@ -551,11 +552,11 @@ var Calendar = /*#__PURE__*/function (_Component) {
       var valueArray = [].concat(value);
       return React.createElement("div", {
         className: mergeClassNames(baseClassName, selectRange && valueArray.length === 1 && "".concat(baseClassName, "--selectRange"), showDoubleView && "".concat(baseClassName, "--doubleView"), className)
-      }, this.renderNavigation(), React.createElement("div", {
+      }, this.renderNavigation(false, 'hideMonth'), React.createElement("div", {
         className: "".concat(baseClassName, "__viewContainer"),
         onBlur: selectRange ? onMouseLeave : null,
         onMouseLeave: selectRange ? onMouseLeave : null
-      }, this.renderContent(), showDoubleView && showSeparateMonthLabel && this.renderNavigation(true), showDoubleView && this.renderContent(true)));
+      }, this.renderNavigation(false, 'monthonly'), this.renderContent(), showDoubleView && showSeparateMonthLabel && this.renderNavigation(true), showDoubleView && this.renderContent(true)));
     }
   }, {
     key: "activeStartDate",
@@ -677,11 +678,11 @@ Calendar.propTypes = {
   prevLabel: PropTypes.node,
   returnValue: PropTypes.oneOf(['start', 'end', 'range']),
   selectRange: PropTypes.bool,
-  showSeparateMonthLabel: PropTypes.bool,
   showDoubleView: PropTypes.bool,
   showFixedNumberOfWeeks: PropTypes.bool,
   showNavigation: PropTypes.bool,
   showNeighboringMonth: PropTypes.bool,
+  showSeparateMonthLabel: PropTypes.bool,
   showWeekNumbers: PropTypes.bool,
   tileClassName: PropTypes.oneOfType([PropTypes.func, isClassName]),
   tileContent: PropTypes.oneOfType([PropTypes.func, PropTypes.node]),

--- a/dist/esm/Calendar/Navigation.js
+++ b/dist/esm/Calendar/Navigation.js
@@ -11,6 +11,8 @@ export default function Navigation(_ref) {
       formatMonthYear = _ref$formatMonthYear === void 0 ? defaultFormatMonthYear : _ref$formatMonthYear,
       _ref$formatYear = _ref.formatYear,
       formatYear = _ref$formatYear === void 0 ? defaultFormatYear : _ref$formatYear,
+      _ref$mode = _ref.mode,
+      mode = _ref$mode === void 0 ? 'normal' : _ref$mode,
       locale = _ref.locale,
       maxDate = _ref.maxDate,
       minDate = _ref.minDate,
@@ -116,7 +118,7 @@ export default function Navigation(_ref) {
       style: {
         display: 'flex'
       }
-    }, React.createElement("button", {
+    }, mode !== 'hideMonth' && React.createElement("button", {
       "aria-label": navigationAriaLabel,
       className: "".concat(className, "__label"),
       disabled: !drillUpAvailable,
@@ -128,12 +130,13 @@ export default function Navigation(_ref) {
     }, renderLabel(nextActiveStartDate)));
   }
 
+  console.log('mode:', mode);
   return React.createElement("div", {
     className: className,
     style: {
       display: 'flex'
     }
-  }, prev2Label !== null && shouldShowPrevNext2Buttons && React.createElement("button", {
+  }, mode !== 'monthonly' && React.createElement(React.Fragment, null, prev2Label !== null && shouldShowPrevNext2Buttons && React.createElement("button", {
     "aria-label": prev2AriaLabel,
     className: "".concat(className, "__arrow ").concat(className, "__prev2-button"),
     disabled: prev2ButtonDisabled,
@@ -145,7 +148,7 @@ export default function Navigation(_ref) {
     disabled: prevButtonDisabled,
     onClick: onClickPrevious,
     type: "button"
-  }, prevLabel), React.createElement("button", {
+  }, prevLabel)), mode !== 'hideMonth' && React.createElement("button", {
     "aria-label": navigationAriaLabel,
     className: "".concat(className, "__label"),
     disabled: !drillUpAvailable,
@@ -154,7 +157,7 @@ export default function Navigation(_ref) {
       flexGrow: 1
     },
     type: "button"
-  }, renderLabel(activeStartDate), !showSeparateMonthLabel && showDoubleView && React.createElement(React.Fragment, null, ' ', "\u2013", ' ', renderLabel(nextActiveStartDate))), React.createElement("button", {
+  }, renderLabel(activeStartDate), !showSeparateMonthLabel && showDoubleView && React.createElement(React.Fragment, null, ' ', "\u2013", ' ', renderLabel(nextActiveStartDate))), mode !== 'monthonly' && React.createElement(React.Fragment, null, React.createElement("button", {
     "aria-label": nextAriaLabel,
     className: "".concat(className, "__arrow ").concat(className, "__next-button"),
     disabled: nextButtonDisabled,
@@ -166,7 +169,7 @@ export default function Navigation(_ref) {
     disabled: next2ButtonDisabled,
     onClick: onClickNext2,
     type: "button"
-  }, next2Label));
+  }, next2Label)));
 }
 Navigation.propTypes = {
   activeStartDate: PropTypes.instanceOf(Date).isRequired,
@@ -176,6 +179,7 @@ Navigation.propTypes = {
   locale: PropTypes.string,
   maxDate: PropTypes.instanceOf(Date),
   minDate: PropTypes.instanceOf(Date),
+  mode: PropTypes.string,
   navigationAriaLabel: PropTypes.string,
   navigationLabel: PropTypes.func,
   next2AriaLabel: PropTypes.string,
@@ -188,8 +192,8 @@ Navigation.propTypes = {
   prevLabel: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   secoundMonth: PropTypes.bool,
   setActiveStartDate: PropTypes.func.isRequired,
-  showSeparateMonthLabel: PropTypes.bool,
   showDoubleView: PropTypes.bool,
+  showSeparateMonthLabel: PropTypes.bool,
   view: isView.isRequired,
   views: isViews.isRequired
 };

--- a/dist/umd/Calendar.js
+++ b/dist/umd/Calendar.js
@@ -508,7 +508,7 @@ var Calendar = /*#__PURE__*/function (_Component) {
     }
   }, {
     key: "renderNavigation",
-    value: function renderNavigation(secound) {
+    value: function renderNavigation(secound, mode) {
       var showNavigation = this.props.showNavigation;
 
       if (!showNavigation) {
@@ -544,6 +544,7 @@ var Calendar = /*#__PURE__*/function (_Component) {
         locale: locale,
         maxDate: maxDate,
         minDate: minDate,
+        mode: mode,
         navigationAriaLabel: navigationAriaLabel,
         navigationLabel: navigationLabel,
         next2AriaLabel: next2AriaLabel,
@@ -575,11 +576,11 @@ var Calendar = /*#__PURE__*/function (_Component) {
       var valueArray = [].concat(value);
       return _react["default"].createElement("div", {
         className: (0, _mergeClassNames["default"])(baseClassName, selectRange && valueArray.length === 1 && "".concat(baseClassName, "--selectRange"), showDoubleView && "".concat(baseClassName, "--doubleView"), className)
-      }, this.renderNavigation(), _react["default"].createElement("div", {
+      }, this.renderNavigation(false, 'hideMonth'), _react["default"].createElement("div", {
         className: "".concat(baseClassName, "__viewContainer"),
         onBlur: selectRange ? onMouseLeave : null,
         onMouseLeave: selectRange ? onMouseLeave : null
-      }, this.renderContent(), showDoubleView && showSeparateMonthLabel && this.renderNavigation(true), showDoubleView && this.renderContent(true)));
+      }, this.renderNavigation(false, 'monthonly'), this.renderContent(), showDoubleView && showSeparateMonthLabel && this.renderNavigation(true), showDoubleView && this.renderContent(true)));
     }
   }, {
     key: "activeStartDate",
@@ -704,11 +705,11 @@ Calendar.propTypes = {
   prevLabel: _propTypes["default"].node,
   returnValue: _propTypes["default"].oneOf(['start', 'end', 'range']),
   selectRange: _propTypes["default"].bool,
-  showSeparateMonthLabel: _propTypes["default"].bool,
   showDoubleView: _propTypes["default"].bool,
   showFixedNumberOfWeeks: _propTypes["default"].bool,
   showNavigation: _propTypes["default"].bool,
   showNeighboringMonth: _propTypes["default"].bool,
+  showSeparateMonthLabel: _propTypes["default"].bool,
   showWeekNumbers: _propTypes["default"].bool,
   tileClassName: _propTypes["default"].oneOfType([_propTypes["default"].func, _propTypes2.isClassName]),
   tileContent: _propTypes["default"].oneOfType([_propTypes["default"].func, _propTypes["default"].node]),

--- a/dist/umd/Calendar/Navigation.js
+++ b/dist/umd/Calendar/Navigation.js
@@ -26,6 +26,8 @@ function Navigation(_ref) {
       formatMonthYear = _ref$formatMonthYear === void 0 ? _dateFormatter.formatMonthYear : _ref$formatMonthYear,
       _ref$formatYear = _ref.formatYear,
       formatYear = _ref$formatYear === void 0 ? _dateFormatter.formatYear : _ref$formatYear,
+      _ref$mode = _ref.mode,
+      mode = _ref$mode === void 0 ? 'normal' : _ref$mode,
       locale = _ref.locale,
       maxDate = _ref.maxDate,
       minDate = _ref.minDate,
@@ -131,7 +133,7 @@ function Navigation(_ref) {
       style: {
         display: 'flex'
       }
-    }, _react["default"].createElement("button", {
+    }, mode !== 'hideMonth' && _react["default"].createElement("button", {
       "aria-label": navigationAriaLabel,
       className: "".concat(className, "__label"),
       disabled: !drillUpAvailable,
@@ -143,12 +145,13 @@ function Navigation(_ref) {
     }, renderLabel(nextActiveStartDate)));
   }
 
+  console.log('mode:', mode);
   return _react["default"].createElement("div", {
     className: className,
     style: {
       display: 'flex'
     }
-  }, prev2Label !== null && shouldShowPrevNext2Buttons && _react["default"].createElement("button", {
+  }, mode !== 'monthonly' && _react["default"].createElement(_react["default"].Fragment, null, prev2Label !== null && shouldShowPrevNext2Buttons && _react["default"].createElement("button", {
     "aria-label": prev2AriaLabel,
     className: "".concat(className, "__arrow ").concat(className, "__prev2-button"),
     disabled: prev2ButtonDisabled,
@@ -160,7 +163,7 @@ function Navigation(_ref) {
     disabled: prevButtonDisabled,
     onClick: onClickPrevious,
     type: "button"
-  }, prevLabel), _react["default"].createElement("button", {
+  }, prevLabel)), mode !== 'hideMonth' && _react["default"].createElement("button", {
     "aria-label": navigationAriaLabel,
     className: "".concat(className, "__label"),
     disabled: !drillUpAvailable,
@@ -169,7 +172,7 @@ function Navigation(_ref) {
       flexGrow: 1
     },
     type: "button"
-  }, renderLabel(activeStartDate), !showSeparateMonthLabel && showDoubleView && _react["default"].createElement(_react["default"].Fragment, null, ' ', "\u2013", ' ', renderLabel(nextActiveStartDate))), _react["default"].createElement("button", {
+  }, renderLabel(activeStartDate), !showSeparateMonthLabel && showDoubleView && _react["default"].createElement(_react["default"].Fragment, null, ' ', "\u2013", ' ', renderLabel(nextActiveStartDate))), mode !== 'monthonly' && _react["default"].createElement(_react["default"].Fragment, null, _react["default"].createElement("button", {
     "aria-label": nextAriaLabel,
     className: "".concat(className, "__arrow ").concat(className, "__next-button"),
     disabled: nextButtonDisabled,
@@ -181,7 +184,7 @@ function Navigation(_ref) {
     disabled: next2ButtonDisabled,
     onClick: onClickNext2,
     type: "button"
-  }, next2Label));
+  }, next2Label)));
 }
 
 Navigation.propTypes = {
@@ -192,6 +195,7 @@ Navigation.propTypes = {
   locale: _propTypes["default"].string,
   maxDate: _propTypes["default"].instanceOf(Date),
   minDate: _propTypes["default"].instanceOf(Date),
+  mode: _propTypes["default"].string,
   navigationAriaLabel: _propTypes["default"].string,
   navigationLabel: _propTypes["default"].func,
   next2AriaLabel: _propTypes["default"].string,
@@ -204,8 +208,8 @@ Navigation.propTypes = {
   prevLabel: _propTypes["default"].oneOfType([_propTypes["default"].string, _propTypes["default"].node]),
   secoundMonth: _propTypes["default"].bool,
   setActiveStartDate: _propTypes["default"].func.isRequired,
-  showSeparateMonthLabel: _propTypes["default"].bool,
   showDoubleView: _propTypes["default"].bool,
+  showSeparateMonthLabel: _propTypes["default"].bool,
   view: _propTypes2.isView.isRequired,
   views: _propTypes2.isViews.isRequired
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-calendar",
-  "version": "3.0.0-beta.5",
+  "version": "3.0.1",
   "description": "Ultimate calendar for your React app.",
   "main": "dist/umd/index.js",
   "module": "dist/esm/index.js",

--- a/src/Calendar.jsx
+++ b/src/Calendar.jsx
@@ -459,7 +459,7 @@ export default class Calendar extends Component {
     }
   }
 
-  renderNavigation(secound) {
+  renderNavigation(secound, mode) {
     const { showNavigation } = this.props;
 
     if (!showNavigation) {
@@ -496,6 +496,7 @@ export default class Calendar extends Component {
         locale={locale}
         maxDate={maxDate}
         minDate={minDate}
+        mode={mode}
         navigationAriaLabel={navigationAriaLabel}
         navigationLabel={navigationLabel}
         next2AriaLabel={next2AriaLabel}
@@ -532,12 +533,13 @@ export default class Calendar extends Component {
           className,
         )}
       >
-        {this.renderNavigation()}
+        {this.renderNavigation(false, 'hideMonth')}
         <div
           className={`${baseClassName}__viewContainer`}
           onBlur={selectRange ? onMouseLeave : null}
           onMouseLeave={selectRange ? onMouseLeave : null}
         >
+          {this.renderNavigation(false, 'monthonly')}
           {this.renderContent()}
           {showDoubleView && showSeparateMonthLabel && this.renderNavigation(true)}
 
@@ -601,11 +603,11 @@ Calendar.propTypes = {
   prevLabel: PropTypes.node,
   returnValue: PropTypes.oneOf(['start', 'end', 'range']),
   selectRange: PropTypes.bool,
-  showSeparateMonthLabel: PropTypes.bool,
   showDoubleView: PropTypes.bool,
   showFixedNumberOfWeeks: PropTypes.bool,
   showNavigation: PropTypes.bool,
   showNeighboringMonth: PropTypes.bool,
+  showSeparateMonthLabel: PropTypes.bool,
   showWeekNumbers: PropTypes.bool,
   tileClassName: PropTypes.oneOfType([
     PropTypes.func,

--- a/src/Calendar/Navigation.jsx
+++ b/src/Calendar/Navigation.jsx
@@ -24,6 +24,7 @@ export default function Navigation({
   drillUp,
   formatMonthYear = defaultFormatMonthYear,
   formatYear = defaultFormatYear,
+  mode = 'normal',
   locale,
   maxDate,
   minDate,
@@ -123,6 +124,8 @@ export default function Navigation({
         className={className}
         style={{ display: 'flex' }}
       >
+        {mode !== 'hideMonth'
+        && (
         <button
           aria-label={navigationAriaLabel}
           className={`${className}__label`}
@@ -133,17 +136,20 @@ export default function Navigation({
         >
           {renderLabel(nextActiveStartDate)}
         </button>
+        )}
       </div>
     );
   }
-
 
   return (
     <div
       className={className}
       style={{ display: 'flex' }}
     >
-      {prev2Label !== null && shouldShowPrevNext2Buttons && (
+      {mode !== 'monthonly'
+      && (
+      <>
+        {prev2Label !== null && shouldShowPrevNext2Buttons && (
         <button
           aria-label={prev2AriaLabel}
           className={`${className}__arrow ${className}__prev2-button`}
@@ -153,54 +159,65 @@ export default function Navigation({
         >
           {prev2Label}
         </button>
+        )}
+        <button
+          aria-label={prevAriaLabel}
+          className={`${className}__arrow ${className}__prev-button`}
+          disabled={prevButtonDisabled}
+          onClick={onClickPrevious}
+          type="button"
+        >
+          {prevLabel}
+        </button>
+      </>
       )}
-      <button
-        aria-label={prevAriaLabel}
-        className={`${className}__arrow ${className}__prev-button`}
-        disabled={prevButtonDisabled}
-        onClick={onClickPrevious}
-        type="button"
-      >
-        {prevLabel}
-      </button>
-      <button
-        aria-label={navigationAriaLabel}
-        className={`${className}__label`}
-        disabled={!drillUpAvailable}
-        onClick={drillUp}
-        style={{ flexGrow: 1 }}
-        type="button"
-      >
-        {renderLabel(activeStartDate)}
-        {!showSeparateMonthLabel && showDoubleView && (
+
+      {mode !== 'hideMonth'
+        && (
+        <button
+          aria-label={navigationAriaLabel}
+          className={`${className}__label`}
+          disabled={!drillUpAvailable}
+          onClick={drillUp}
+          style={{ flexGrow: 1 }}
+          type="button"
+        >
+          {renderLabel(activeStartDate)}
+          {!showSeparateMonthLabel && showDoubleView && (
           <>
             {' '}
             –
             {' '}
             {renderLabel(nextActiveStartDate)}
           </>
-        )}
-      </button>
-      <button
-        aria-label={nextAriaLabel}
-        className={`${className}__arrow ${className}__next-button`}
-        disabled={nextButtonDisabled}
-        onClick={onClickNext}
-        type="button"
-      >
-        {nextLabel}
-      </button>
-      {next2Label !== null && shouldShowPrevNext2Buttons && (
-        <button
-          aria-label={next2AriaLabel}
-          className={`${className}__arrow ${className}__next2-button`}
-          disabled={next2ButtonDisabled}
-          onClick={onClickNext2}
-          type="button"
-        >
-          {next2Label}
+          )}
         </button>
-      )}
+        )}
+      {mode !== 'monthonly'
+        && (
+        <>
+          <button
+            aria-label={nextAriaLabel}
+            className={`${className}__arrow ${className}__next-button`}
+            disabled={nextButtonDisabled}
+            onClick={onClickNext}
+            type="button"
+          >
+            {nextLabel}
+          </button>
+          {next2Label !== null && shouldShowPrevNext2Buttons && (
+          <button
+            aria-label={next2AriaLabel}
+            className={`${className}__arrow ${className}__next2-button`}
+            disabled={next2ButtonDisabled}
+            onClick={onClickNext2}
+            type="button"
+          >
+            {next2Label}
+          </button>
+          )}
+        </>
+        )}
     </div>
   );
 }
@@ -213,6 +230,7 @@ Navigation.propTypes = {
   locale: PropTypes.string,
   maxDate: PropTypes.instanceOf(Date),
   minDate: PropTypes.instanceOf(Date),
+  mode: PropTypes.string,
   navigationAriaLabel: PropTypes.string,
   navigationLabel: PropTypes.func,
   next2AriaLabel: PropTypes.string,
@@ -225,8 +243,8 @@ Navigation.propTypes = {
   prevLabel: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   secoundMonth: PropTypes.bool,
   setActiveStartDate: PropTypes.func.isRequired,
-  showSeparateMonthLabel: PropTypes.bool,
   showDoubleView: PropTypes.bool,
+  showSeparateMonthLabel: PropTypes.bool,
   view: isView.isRequired,
   views: isViews.isRequired,
 };


### PR DESCRIPTION
ナビゲーションと月表示の分離

月とナビゲーションを別々に表示するように変更

月はコンテイナーの中に配置

![May-11-2020 13-51-13](https://user-images.githubusercontent.com/60123733/81525258-0dd6aa80-938f-11ea-9dbf-25f64c65dad1.gif)


